### PR TITLE
feat: toast error and success message when creating a wishlist

### DIFF
--- a/react/components/WishlistDesktop.tsx
+++ b/react/components/WishlistDesktop.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React, { useState, useContext } from 'react'
+import { ToastContext } from 'vtex.styleguide'
 
 import EditableWishlistTitle from './WishlistName/WishlistName'
 import ModalCreateList from './ModalCreateList'
@@ -28,6 +29,7 @@ const WishlistDesktop = ({
 }) => {
   const [isCreateLoading, setIsCreateLoading] = useState(false)
   const [isDeleteLoading, setIsDeleteLoading] = useState(false)
+  const { showToast } = useContext<any>(ToastContext)
 
   const onCreateList = async (event) => {
     setIsCreateLoading(true)
@@ -40,8 +42,10 @@ const WishlistDesktop = ({
         setNameListAccountTable,
         setIsModalAccountTable,
       })
+      showToast('You created a new Wishlist and your product was added')
       setIsCreateLoading(false)
     } catch (error) {
+      showToast(error)
       console.error(error)
       await fetchData()
       setIsCreateLoading(false)

--- a/react/components/WishlistMobile.tsx
+++ b/react/components/WishlistMobile.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React, { useState, useContext } from 'react'
+import { ToastContext } from 'vtex.styleguide'
 
 import EditableWishlistTitle from './WishlistName/WishlistName'
 import ModalCreateList from './ModalCreateList'
@@ -27,6 +28,7 @@ const WishlistMobile = ({
   isDeleting,
 }) => {
   const [isCreateLoading, setIsCreateLoading] = useState(false)
+  const { showToast } = useContext<any>(ToastContext)
 
   const onCreateList = async (event: React.FormEvent) => {
     setIsCreateLoading(true)
@@ -39,8 +41,10 @@ const WishlistMobile = ({
         setNameListAccountTable,
         setIsModalAccountTable,
       })
+      showToast('You created a new Wishlist and your product was added')
       setIsCreateLoading(false)
     } catch (error) {
+      showToast(error)
       console.error(error)
       setIsCreateLoading(false)
     }


### PR DESCRIPTION
Add an error message that is displayed on screen when the user tries to create a wishlist that has the same name as another wishlist that has already been registered.