### PR TITLE
fix: use of the correct handleAddToList function 

### DIFF
--- a/react/components/buttonWishlist/ButtonWishlist.tsx
+++ b/react/components/buttonWishlist/ButtonWishlist.tsx
@@ -31,7 +31,6 @@ const ButtonWishlist = () => {
     isMessage,
     isShowForm2,
     clickCreate,
-    setIsButton,
     errorName,
     isLoading,
   } = useGetWishlist()
@@ -110,7 +109,6 @@ const ButtonWishlist = () => {
                   handleSendData2={sendData2}
                   clickCreate={clickCreate}
                   handleCloseModal={() => setIsShowSelect(false)}
-                  setIsButton={setIsButton}
                   handleCreateLengthZero={createLengthZero}
                   selectRef={selectRef}
                   selectSize={selectSize}

--- a/react/components/selectWishlists/selectWishlist.tsx
+++ b/react/components/selectWishlists/selectWishlist.tsx
@@ -82,7 +82,7 @@ const SelectWishlist = (props: SelectWishList) => {
                     <>
                       <button
                         className={`${handles.containerButtonAddList}`}
-                        onClick={props.handleAddList}
+                        onClick={props.handleAddToList}
                       >
                         Add to list
                       </button>

--- a/react/hooks/useGetWishlists.tsx
+++ b/react/hooks/useGetWishlists.tsx
@@ -173,7 +173,6 @@ const useGetWishlist = () => {
     isLoading,
     setIsShowSelect,
     setIsShowForm,
-    setIsButton,
     handleChange,
     addList,
     sendData1,

--- a/react/hooks/useSelectWishlist.tsx
+++ b/react/hooks/useSelectWishlist.tsx
@@ -62,7 +62,7 @@ const useSelectWishlist = () => {
   }
 
   const addToList = () => {
-    if (textSelect.trim() === '') {
+    if (textSelect.trim().length === 0) {
       setErrorSelect('Select a list to save your product')
 
       return

--- a/react/interfaces/index.ts
+++ b/react/interfaces/index.ts
@@ -4,7 +4,6 @@ export interface SelectWishList {
   nameListWishlist: string
   handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void
   isButton: boolean
-  setIsButton?: React.Dispatch<React.SetStateAction<boolean>>
   isMessage: boolean
   isShowForm2: boolean
   handleAddList: () => void


### PR DESCRIPTION
The button to add a product to an existing list was not working, because it was using the handleAddList function instead of the correct handleAddToList function.

Some setState props that were not being used have also been removed.