### PR TITLE
Fix/delay on loading existing lists

### DIFF
--- a/node/resolvers/createWishlist.ts
+++ b/node/resolvers/createWishlist.ts
@@ -2,8 +2,9 @@ import type { WishlistInput } from '../typings/wishlist'
 import { auth } from '../middleware/auth'
 
 function hasSpecialCharacters(str: string) {
-  const specialCharactersRegex = /[!@$%^*(),.?":{}|<>]/g;
-  return specialCharactersRegex.test(str);
+  const specialCharactersRegex = /[!@$%^*(),.?":{}|<>]/g
+
+  return specialCharactersRegex.test(str)
 }
 
 export const createWishlist = async (
@@ -19,15 +20,17 @@ export const createWishlist = async (
 
   const { email } = await auth(ctx)
 
-  if(hasSpecialCharacters(wishlistType)) {
-    throw new Error(`An error occurred. No special characters are allowed in the name.`)
+  if (hasSpecialCharacters(wishlistType)) {
+    throw new Error(
+      `An error occurred. No special characters are allowed in the name.`
+    )
   }
 
   const foundWishlist = await md.searchForExistingWishList(
     `wishlistType = "${encodeURIComponent(wishlistType)}" AND email = ${email}`
   )
-  
-  const existWishlistName = foundWishlist?.length > 0
+
+  const existWishlistName = foundWishlist && foundWishlist.length > 0
 
   if (existWishlistName) {
     throw new Error(`Already exist wishlist with name ${wishlistType}`)

--- a/node/resolvers/getWishlistsByEmail.ts
+++ b/node/resolvers/getWishlistsByEmail.ts
@@ -26,5 +26,5 @@ export const getWishlistsByEmail = async (
 
   const wishlists = await md.searchWistlist('email', email, pagination)
 
-  return wishlists || []
+  return wishlists || null
 }

--- a/react/components/MyWishLists.tsx
+++ b/react/components/MyWishLists.tsx
@@ -19,7 +19,7 @@ import CREATE_WISHLIST from '../mutation/createWishList.gql'
 const MyWishLists = () => {
   const [isLoading, setIsLoading] = useState(false)
   const [isLoadingPage, setIsLoadingPage] = useState(false)
-  const [errorMessage, setErrorMessage] = useState('')
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const { setSelectedWishlist, selectedWishlist } = useStoreGlobal()
   const setWishlists = useStoreGlobal((state) => state.setWishlists)
   const wishlists = useStoreGlobal((state) => state.wishlists)
@@ -54,8 +54,6 @@ const MyWishLists = () => {
 
     if (error) {
       setErrorMessage(error.message)
-    } else {
-      setErrorMessage('Error')
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/react/components/MyWishLists.tsx
+++ b/react/components/MyWishLists.tsx
@@ -18,11 +18,13 @@ import CREATE_WISHLIST from '../mutation/createWishList.gql'
 
 const MyWishLists = () => {
   const [isLoading, setIsLoading] = useState(false)
+  const [isLoadingPage, setIsLoadingPage] = useState(false)
+  const [errorMessage, setErrorMessage] = useState('')
   const { setSelectedWishlist, selectedWishlist } = useStoreGlobal()
   const setWishlists = useStoreGlobal((state) => state.setWishlists)
   const wishlists = useStoreGlobal((state) => state.wishlists)
 
-  const { data, loading, refetch } = useQueryWishlists()
+  const { data, loading, refetch, error } = useQueryWishlists()
 
   const [createNewListMutaion] = useMutation(CREATE_WISHLIST, {})
 
@@ -39,15 +41,29 @@ const MyWishLists = () => {
   } = useCreateListAccount()
 
   useEffect(() => {
-    if (data?.getWishlistsByEmail?.length > 0) {
-      setWishlists(data.getWishlistsByEmail)
-
-      if (!selectedWishlist) {
-        setSelectedWishlist(data.getWishlistsByEmail[0].id)
+    if (data?.getWishlistsByEmail) {
+      if (data.getWishlistsByEmail.length > 0) {
+        setWishlists(data.getWishlistsByEmail)
+        if (!selectedWishlist) {
+          setSelectedWishlist(data.getWishlistsByEmail[0].id)
+        }
+      } else {
+        setWishlists([])
       }
     }
+
+    if (error) {
+      setErrorMessage(error.message)
+    } else {
+      setErrorMessage('Error')
+    }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data])
+  }, [data, error])
+
+  useEffect(() => {
+    wishlists && setIsLoadingPage(loading)
+  }, [loading, wishlists])
 
   // Create list post
   const handleSubmitData = (event: { preventDefault: () => void }) => {
@@ -73,8 +89,8 @@ const MyWishLists = () => {
           setIsModalAccount(false)
           setIsLoading(false)
         })
-        .catch((error) => {
-          console.error(error)
+        .catch((errorSubmit) => {
+          console.error(errorSubmit)
           setNameListAccount('')
           setFieldValidation('')
           setIsModalAccount(false)
@@ -88,13 +104,22 @@ const MyWishLists = () => {
     buttonCloseModal()
   }
 
-  if (loading) return <Spinner />
+  if (errorMessage)
+    return (
+      <p className={styles.errorMessage}>
+        Could not find the wishlists: {errorMessage}
+      </p>
+    )
+
+  if (isLoadingPage) return <Spinner />
 
   if (wishlists.length === 0) {
     return (
       <section className={styles.wishlistCreateWishlistUI}>
         <Button href="/account">RETURN</Button>
-        <h1 className={styles.wishlistCreateWishlistPageTitle}>Create your wishlist!</h1>
+        <h1 className={styles.wishlistCreateWishlistPageTitle}>
+          Create your wishlist!
+        </h1>
         <button className={styles.wishlistCreateNew} onClick={buttonModal}>
           New Wishlist
         </button>


### PR DESCRIPTION
Sometimes the request was taking a long time to complete (perhaps because of a connection or some problem with the MDv2 entity search) and I think that's why a “create list” screen was being displayed, even when the user already had lists created.

The way I found to solve this was to make the component handle the request error and display it on the screen. This way, the user will have a visual feedback as to why their lists weren't loaded.

Another adjustment I made was to add a retry to the request, so that a new attempt is made to fetch the data, before displaying the error.