### PR TITLE
Fix/event gtm add to cart

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@types/node": "^12.0.0",
     "@types/ramda": "types/npm-ramda#dist",
-    "@vtex/api": "6.47.0",
+    "@vtex/api": "6.48.0",
     "@vtex/test-tools": "^3.4.3",
     "@vtex/tsconfig": "^0.5.6",
     "typescript": "3.9.7",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1814,10 +1814,10 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.7.tgz#114e2ffc8d5be4915fdd5bc90668fc0ceaadb760"
   integrity sha512-LKzNTjj+2j09wAo/vvVjzgw5qckJJzhdGgWHW7j69QIGdq/KnZrMAMIHQiWGl3Ccflh5/CudBAntTPYdprPltA==
 
-"@vtex/api@6.47.0":
-  version "6.47.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.47.0.tgz#6910455d593d8bb76f1f4f2b7660023853fda35e"
-  integrity sha512-t9gt7Q89EMbSj3rLhho+49Fv+/lQgiy8EPVRgtmmXFp1J4v8hIAZF7GPjCPie111KVs4eG0gfZFpmhA5dafKNA==
+"@vtex/api@6.48.0":
+  version "6.48.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.48.0.tgz#67f9f11d197d543d4f854b057d31a8d6999241e9"
+  integrity sha512-mAdT7gbV0/BwiuqUkNH1E7KZqTUczT5NbBBZcPJq5kmTr73PUjbR9wh//70ryJo2EAdHlqIgqgwsCVpozenlhg==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"
@@ -5984,7 +5984,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/react/components/TableShare/index.tsx
+++ b/react/components/TableShare/index.tsx
@@ -18,7 +18,11 @@ import styles from '../../styles.css'
 import { getProductPath } from '../../utils/jsonSchema'
 import ProductPriceTotal from '../ProductPriceTotal'
 import UnitPrice from '../UnitPrice'
-import { AdminSettings, PublicSettingsForApp } from '../../interfaces'
+import {
+  AdminSettings,
+  PublicSettingsForApp,
+  WishlistMD,
+} from '../../interfaces'
 import useAddToCart from '../../hooks/useAddToCart'
 
 const CSS_HANDLES = [
@@ -31,18 +35,18 @@ interface ITableWishListColumns {
   publicSettingsForApp: PublicSettingsForApp
 }
 export default function TableWishList({
-  products,
+  wishlistMD,
   queryId,
   columns,
 }: {
-  products: any
+  wishlistMD: WishlistMD
   queryId: string
   columns: ITableWishListColumns
 }) {
   const { showToast } = useContext(ToastContext)
   const { handles } = useCssHandles(CSS_HANDLES)
   const [localProducts, setLocalProducts] = useState([
-    ...products.map((product: any) => ({
+    ...wishlistMD?.products.map((product: any) => ({
       ...product,
       unitValue: product.unitValue ?? 0,
       totalValue: product.quantityProduct * (product.unitValue ?? 0),
@@ -159,7 +163,7 @@ export default function TableWishList({
                 localProducts?.find((product) => product.ID === rowData.ID)
                   ?.qty ?? rowData.quantity,
             },
-            { products }
+            wishlistMD
           )
         }
       >
@@ -177,7 +181,11 @@ export default function TableWishList({
     fieldValidationTable,
     handleNameListTable,
     createNewList,
-  } = useAddSharedListPage({ queryId, products, updatedProducts: null })
+  } = useAddSharedListPage({
+    queryId,
+    products: wishlistMD.products,
+    updatedProducts: null,
+  })
 
   const skuNameCellRenderer = ({ rowData }) => {
     const productUrl = getProductPath(rowData)

--- a/react/components/Wishlist.tsx
+++ b/react/components/Wishlist.tsx
@@ -2,8 +2,9 @@
 import React, { useEffect, useState, useContext, useCallback } from 'react'
 import { Table, ToastContext } from 'vtex.styleguide'
 import { useRuntime } from 'vtex.render-runtime'
-
 // Components
+import { useQuery } from 'react-apollo'
+
 import AutocompleteBlock from './SearchSKU/AutocompleteBlock'
 import useCreateListAccount from '../hooks/useCreateListAccount'
 // Helpers & Utils
@@ -17,8 +18,6 @@ import useBulkAction from '../hooks/useBulkAction'
 import { JsonSchema } from '../utils/jsonSchema'
 import useStoreGlobal from '../globalStore/globalStore'
 import AppSettings from '../queries/AppSettings.graphql'
-
-
 // Table config
 import {
   handleNextClick,
@@ -37,14 +36,8 @@ import WishlistDesktop from './WishlistDesktop'
 import WishlistMobile from './WishlistMobile'
 // Styles
 import styles from '../styles.css'
-import { useQuery } from 'react-apollo'
 
-
-
-
-
-
-function Wishlist({ wishlists, fetchData}) {
+function Wishlist({ wishlists, fetchData }) {
   const { deviceInfo } = useRuntime()
   const emailIDInfo = getEmailID(wishlists)
   const { selectedWishlist, setSelectedWishlist } = useStoreGlobal()
@@ -157,7 +150,6 @@ function Wishlist({ wishlists, fetchData}) {
     updateWishlist,
     wishlistColumns,
   })
-
 
   const {
     fieldValidationTable,
@@ -353,7 +345,7 @@ function Wishlist({ wishlists, fetchData}) {
       department: productData?.categoryTree?.[0]?.name,
       bundle: hasBundle ? unitMultiplierValue : item.unitMultiplier,
     }
- 
+
     if (newProduct.bundle > 1) {
       newProduct.quantityProduct *= newProduct.bundle
     }
@@ -386,7 +378,7 @@ function Wishlist({ wishlists, fetchData}) {
       setIsLoadingSKU(false)
     }
   }
-  
+
   const tableFilterOptions = {
     department: {
       label: 'Department',
@@ -531,7 +523,7 @@ function Wishlist({ wishlists, fetchData}) {
         <Table
           fullWidth
           density="medium"
-          updateTableKey={`vtex-table=${Math.floor(Math.random() * 1000) }`}
+          updateTableKey={`vtex-table=${Math.floor(Math.random() * 1000)}`}
           schema={tableSchema}
           items={paginatedData || []}
           toolbar={{

--- a/react/components/WishlistShare.tsx
+++ b/react/components/WishlistShare.tsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import { useRuntime } from 'vtex.render-runtime'
 import { Spinner } from 'vtex.styleguide'
-
 import { useQuery } from 'react-apollo'
-import AppSettings from '../queries/AppSettings.graphql'
 
+import AppSettings from '../queries/AppSettings.graphql'
 import TableShare from './TableShare'
 import GET_WISHLIST_BY_ID from '../graphql/queries/getWishlistById.gql'
-
 import styles from '../styles.css'
+import { WishlistMD } from '../interfaces'
 
 export default function WishlistShare() {
   const { query } = useRuntime()
@@ -27,7 +26,7 @@ export default function WishlistShare() {
     },
     ssr: false,
   })
- 
+
   if (loading) {
     return (
       <div
@@ -43,16 +42,27 @@ export default function WishlistShare() {
     )
   }
 
-  const { products, email } = data?.getWishlist || { products: [], email: '' }
+  const wishlistMD: WishlistMD = data?.getWishlist || {
+    products: [],
+    email: '',
+  }
 
-  const {defaultTitleText} = JSON.parse(wishlistColumns.publicSettingsForApp.message)
+  const { defaultTitleText } = JSON.parse(
+    wishlistColumns.publicSettingsForApp.message
+  )
 
   return (
     <div className={`${styles.wishlistShare}`}>
       <h2 className="flex justify-center mt6">
-        {`${email}'s ${defaultTitleText ?? 'Favorites List'}`}
+        {`${wishlistMD.email}'s ${defaultTitleText ?? 'Favorites List'}`}
       </h2>
-      {products && <TableShare products={products} columns={wishlistColumns} queryId={id} />}
+      {wishlistMD.products && (
+        <TableShare
+          wishlistMD={wishlistMD}
+          columns={wishlistColumns}
+          queryId={id}
+        />
+      )}
     </div>
   )
 }

--- a/react/components/helpers/addProductsToCart.tsx
+++ b/react/components/helpers/addProductsToCart.tsx
@@ -5,6 +5,7 @@ import { usePixel } from 'vtex.pixel-manager'
 
 import extractProductData from './extractProductData'
 
+// function not used in the project
 const AddProductToCart = ({ name }, wishlist) => {
   const { addItems } = useOrderItems()
   const { showToast } = useContext<any>(ToastContext)

--- a/react/components/helpers/addProductsToCart.tsx
+++ b/react/components/helpers/addProductsToCart.tsx
@@ -13,10 +13,12 @@ const AddProductToCart = ({ name }, wishlist) => {
   const data = extractProductData({ items: wishlist.products })
   const product = data.find((item) => name === item.name)
 
+  if (!product) return
+
   const item = {
     id: product.id,
     seller: 1,
-    quantity: product.qty,
+    quantity: product.quantity,
     name: product.name,
   }
 

--- a/react/components/helpers/deleteItemsWishlist.ts
+++ b/react/components/helpers/deleteItemsWishlist.ts
@@ -14,6 +14,8 @@ const deleteItemFromWishlist = async ({
     (item: { name: string }) => item.name === selectedRow.name
   )
 
+  if (!wishlistItem) return
+
   const updatedWishlistProducts = wishlistProducts.filter(
     (item: { id: number }) => item.id !== wishlistItem.id
   )

--- a/react/components/helpers/extractProductData.ts
+++ b/react/components/helpers/extractProductData.ts
@@ -1,4 +1,6 @@
-const extractProductData = ({ items }) => {
+import { WishlistProductItem } from '../../interfaces'
+
+const extractProductData = ({ items }): WishlistProductItem[] => {
   return items?.map(
     ({
       ID,

--- a/react/components/helpers/extractProductData.ts
+++ b/react/components/helpers/extractProductData.ts
@@ -1,6 +1,6 @@
-import { WishlistProductItem } from '../../interfaces'
+import { ExtractedWishlistProductItem } from '../../interfaces'
 
-const extractProductData = ({ items }): WishlistProductItem[] => {
+const extractProductData = ({ items }): ExtractedWishlistProductItem[] => {
   return items?.map(
     ({
       ID,

--- a/react/hooks/actions/useQueryWishlists.tsx
+++ b/react/hooks/actions/useQueryWishlists.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from 'react-apollo'
 import { useEffect } from 'react'
+
 import GET_WISHLISTS from '../../graphql/queries/getWishlists.gql'
 
 const useQueryWishlists = () => {
@@ -15,7 +16,7 @@ const useQueryWishlists = () => {
     const handleRetry = async () => {
       if (error && retryCount < maxRetries) {
         retryCount += 1
-        await new Promise(resolve => setTimeout(resolve, retryTimeout))
+        await new Promise((resolve) => setTimeout(resolve, retryTimeout))
         refetch()
       }
     }

--- a/react/hooks/useAddSharedListPage.ts
+++ b/react/hooks/useAddSharedListPage.ts
@@ -7,24 +7,13 @@ import { useUserEmail } from './useUserEmail'
 import useStoreGlobal from '../globalStore/globalStore'
 import useMutationCreateWishlist from './actions/useMutationCreateWishlist'
 import useQueryWishlists from './actions/useQueryWishlists'
+import { WishlistProduct } from '../interfaces'
 
 interface UseAddSharedListPageProps {
   queryId: string
-  products: any
+  products: WishlistProduct[]
   updatedProducts: any
 }
-
-// interface Product {
-//   id: string
-//   image: string
-//   bundle: string
-//   unitValue: string
-//   linkProduct: string
-//   name: string
-//   qty: number
-//   skuReferenceCode: string
-//   department: string
-// }
 
 export default function useAddSharedListPage({
   queryId,
@@ -107,8 +96,10 @@ export default function useAddSharedListPage({
     } else {
       const listProducts: any[] = []
 
-      if (Object.keys(updatedProducts).length > 0 && updatedProducts.filter( item => item.ID).length) {
-
+      if (
+        Object.keys(updatedProducts).length > 0 &&
+        updatedProducts.filter((item) => item.ID).length
+      ) {
         Object.values(updatedProducts).forEach((prod: any) => {
           const newProduct: any = {
             ID: prod.ID,
@@ -159,7 +150,6 @@ export default function useAddSharedListPage({
       navigate({ to: '/account#/my-wishlists' })
     }
   }
-
 
   // RETURN
   return {

--- a/react/hooks/useAddToCart.ts
+++ b/react/hooks/useAddToCart.ts
@@ -49,15 +49,18 @@ const useAddToCart = () => {
       },
     ]
 
+    if (items.length === 0) return
+
     addItems(items)
-      .then(async () => {
+      .then(() => {
         push({
           event: 'addToCart',
           id: 'addToCart',
+          items: [productInfo],
         })
         showToast('Item added to the cart')
       })
-      .catch((error: any) => {
+      .catch((error) => {
         console.error(error)
       })
   }

--- a/react/hooks/useAddToCart.ts
+++ b/react/hooks/useAddToCart.ts
@@ -1,20 +1,21 @@
 import { useContext } from 'react'
 import { ToastContext } from 'vtex.styleguide'
-import { usePixel } from 'vtex.pixel-manager'
 import { useOrderItems } from 'vtex.order-items/OrderItems'
 import { useOrderForm } from 'vtex.order-manager/OrderForm'
 
 import { extractProductData } from '../components/helpers'
+import handleDataLayerEvent from '../utils/handleDataLayerEvent'
+import { WishlistMD } from '../interfaces'
 
 const useAddToCart = () => {
-  const { push } = usePixel()
   const { addItems } = useOrderItems()
   const { showToast } = useContext<any>(ToastContext)
   const { orderForm } = useOrderForm()
 
+  // hook used to add several products from the wishlist table to the cart
   const addProductsToCart = (
     props: { name: string; itemId: number; quantity?: number },
-    wishlist: any
+    wishlist: WishlistMD
   ) => {
     const productsByOrders = orderForm.items
     const findProductQuantity = productsByOrders?.find(
@@ -53,11 +54,7 @@ const useAddToCart = () => {
 
     addItems(items)
       .then(() => {
-        push({
-          event: 'addToCart',
-          id: 'addToCart',
-          items: [productInfo],
-        })
+        handleDataLayerEvent('addToCart', [productInfo])
         showToast('Item added to the cart')
       })
       .catch((error) => {

--- a/react/hooks/useBulkAction.js
+++ b/react/hooks/useBulkAction.js
@@ -1,20 +1,20 @@
 import { useContext } from 'react'
 import { ToastContext } from 'vtex.styleguide'
 import { useOrderItems } from 'vtex.order-items/OrderItems'
-import { usePixel } from 'vtex.pixel-manager'
 
+import handleDataLayerEvent from '../utils/handleDataLayerEvent'
 import {
   extractProductData,
   formatProductForWishlist,
 } from '../components/helpers'
 
+// wishlist button in my-account, used to add the product from the table row to the cart
 const useBulkAction = ({
   wishlist,
   selectedWishlist,
   setUpdatedSelectedRows,
   updateWishlist,
 }) => {
-  const { push } = usePixel()
   const { addItems } = useOrderItems()
   const { showToast } = useContext(ToastContext)
 
@@ -37,11 +37,7 @@ const useBulkAction = ({
       if (itemsToAdd.length > 0) {
         addItems(itemsToAdd)
           .then(() => {
-            push({
-              event: 'addToCart',
-              id: 'addToCart',
-              items: selectedRows,
-            })
+            handleDataLayerEvent('addToCart', selectedRows)
             showToast('Items added to the cart')
           })
           .catch((error) => {

--- a/react/hooks/useBulkAction.js
+++ b/react/hooks/useBulkAction.js
@@ -40,6 +40,7 @@ const useBulkAction = ({
             push({
               event: 'addToCart',
               id: 'addToCart',
+              items: selectedRows,
             })
             showToast('Items added to the cart')
           })

--- a/react/hooks/useBundleMinQuantity.tsx
+++ b/react/hooks/useBundleMinQuantity.tsx
@@ -1,4 +1,6 @@
-const useBundleMinQuantity = (productContextValue: { properties: any[] }): number => {
+const useBundleMinQuantity = (productContextValue: {
+  properties: any[]
+}): number => {
   const unitMultiplier = productContextValue?.properties?.find(
     (property) => property.name === 'UnitMultiplier'
   )?.values?.[0]

--- a/react/interfaces/index.ts
+++ b/react/interfaces/index.ts
@@ -74,3 +74,16 @@ export interface AdminSettings {
 export interface PublicSettingsForApp {
   message: string
 }
+
+export interface WishlistProductItem {
+  id: number
+  itemId: number
+  image: string
+  department: string
+  skuReferenceCode: string
+  name: string
+  quantity: number
+  linkProduct: string
+  bundle: null | string
+  notes: null | string
+}

--- a/react/interfaces/index.ts
+++ b/react/interfaces/index.ts
@@ -75,7 +75,27 @@ export interface PublicSettingsForApp {
   message: string
 }
 
-export interface WishlistProductItem {
+export interface WishlistMD {
+  email: string
+  wishlistType: string
+  products: WishlistProduct[]
+  isPublic: boolean
+  fieldsConfig: any[]
+}
+
+export interface WishlistProduct {
+  id: number
+  image: string
+  bundle: string | null
+  department: string
+  linkProduct: string
+  nameProduct: string
+  notes: string | null
+  quantityProduct: number
+  skuCodeReference: string
+}
+
+export interface ExtractedWishlistProductItem {
   id: number
   itemId: number
   image: string
@@ -86,4 +106,10 @@ export interface WishlistProductItem {
   linkProduct: string
   bundle: null | string
   notes: null | string
+}
+
+declare global {
+  interface Window {
+    dataLayer: any[]
+  }
 }

--- a/react/utils/handleDataLayerEvent.ts
+++ b/react/utils/handleDataLayerEvent.ts
@@ -1,0 +1,10 @@
+const handleDataLayerEvent = (eventName: string, eventData: unknown[]) => {
+  if (typeof window !== 'undefined') {
+    ;(window.dataLayer ?? []).push({
+      event: eventName,
+      items: eventData,
+    })
+  }
+}
+
+export default handleDataLayerEvent


### PR DESCRIPTION
Fixed the addToCart button, which was not triggering the “addToCart” event.

When I used the hook “usePixel” app to trigger the event, it only sent the name, price, quantity and dimensions of the product, so I replaced it to use window.dataLayer, to send all the data of the product saved in the wishlist.

I also corrected some typing problems in various hooks, adapting the call of some variables, because the addToCart button of the shared wishlist is the same button that adds various products to the cart, in the wishlist table in my-account.